### PR TITLE
Parse markdown to feishu card json

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,21 @@ inputs:
   TXT_MSG:
     description: '要发送的文本消息。如果不为空，将直接发送文本消息；否则发送 GitHub 事件模板消息'
     required: false
+  MSG_TEXT:
+    description: '要发送的 Markdown 富文本内容。如果设置，则发送 Markdown 卡片，可配合 MD_* 选项调整样式'
+    required: false
+  MD_TEXT_SIZE:
+    description: 'Markdown 文本大小，normal 或 heading'
+    required: false
+  MD_TEXT_ALIGN:
+    description: 'Markdown 文本对齐方式，left/center/right'
+    required: false
+  MD_ICON_JSON:
+    description: 'Markdown icon 配置，JSON 字符串，例如 {"tag":"standard_icon","token":"chat-forbidden_outlined","color":"orange"}'
+    required: false
+  MD_HREF_JSON:
+    description: 'Markdown href 配置，JSON 字符串，对应飞书 href 定义'
+    required: false
   DRY_RUN:
     description: '仅打印将要发送的消息而不实际发送（true/1）'
     required: false


### PR DESCRIPTION
Adds support for sending Markdown rich text in Feishu cards with customizable styling options.

This enhancement allows users to define text size, alignment, icons, and hyperlinks directly within the Markdown element of a Feishu card, fully utilizing Feishu's rich text rendering capabilities beyond basic Markdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-3aa40f05-6563-46f3-bd80-544b9480f95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3aa40f05-6563-46f3-bd80-544b9480f95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

